### PR TITLE
New `PAK` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ pakler NVR8-7400_1705_3438_1103.pak
 ```
 
 ```
-Attempting to guess number of sections... guessed: 10
 Header  magic=32725913  crc32=0250e72d  type=00002302  sections=<10>  mtd_parts=<10>
     Section  0 name="uboot1"         version="v1.0.0.1"       start=00000584  len=000437d0  (start=    1412 len=  276432)
     Section  1 name=""               version=""               start=00043d54  len=00000000  (start=  277844 len=       0)
@@ -83,7 +82,6 @@ example:
 pakler ./NT98312_NVR_8IP_REOLINK_L300_130_21060706.pak -e -d newdir
 ```
 ```
-Attempting to guess number of sections... guessed: 11
 output: newdir
 Extracting section 0 (131072 bytes) into newdir/00_header.bin
 Extracting section 1 (18096 bytes) into newdir/01_loader.bin
@@ -114,7 +112,6 @@ pakler NT98312_NVR_8IP_REOLINK_L300_130_21060706.pak -r -n 5 -f patched_fs.bin -
 ````
 
 ```
-Attempting to guess number of sections... guessed: 11
 Input            : NT98312_NVR_8IP_REOLINK_L300_130_21060706.pak
 Output           : patched_fw.pak
 Replacing section: 5

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # pakler
 
-Pakler is a command-line tool used to manipulate `.pak` firmware files
+Pakler is a command-line tool and library used to manipulate `.pak` firmware files
 used by Swann and Reolink devices. You can list, extract, and replace their
 content. It makes it easy to explore and patch firmwares used by various
 NVRs, DVRs and IP cameras.
 
 ## Installing
 
-Note: pakler requires Python 3
+Note: pakler requires Python 3.6+
 
 ### Recommended
 
@@ -35,6 +35,8 @@ Help can be had with:
 ```shell
 pakler -h
 ```
+
+Note: list and extract also work with ZIPs that contain `.pak` files.
 
 ### Viewing content of `.pak` files
 
@@ -104,8 +106,8 @@ use the `-r` command, specify the number of the section to replace with `-n`,
 the file to use as a replacement with `-f`, and the output file to write
 the resulting patched file with `-o`.
 
-Here is an example where we replace the `.pak` file's section #3 with the
-file ""
+Here is an example where we replace the `.pak` file's section #5 with the
+file `patched_fs.bin`
 
 ```shell
 pakler NT98312_NVR_8IP_REOLINK_L300_130_21060706.pak -r -n 5 -f patched_fs.bin -o patched_fw.pak
@@ -155,6 +157,21 @@ Header  magic=32725913  crc32=41ee801c  type=00006202  sections=<11>  mtd_parts=
     Mtd_part name="version"        mtd="/dev/mtd9"       a=0xffffffff  start=0xffffffff  len=0x00000000
 ```
 
+### As a library
+
+Here are a few things you can do with pakler's API:
+
+```py
+from pakler import PAK
+
+with PAK.from_file("firmware.pak") as pak:  # Also from_bytes() and from_fd()
+    assert pak.crc == pak.calc_crc()
+    pak.extract("firmware_extracted")
+    print(pak.partitions)
+    section = pak.sections[0]
+    pak.save_section(section, f"{section.name}.bin")
+    section_bytes = pak.extract_section(section)
+```
 
 ## Naming
 

--- a/README.md
+++ b/README.md
@@ -47,26 +47,26 @@ pakler NVR8-7400_1705_3438_1103.pak
 
 ```
 Header  magic=32725913  crc32=0250e72d  type=00002302  sections=<10>  mtd_parts=<10>
-    Section  0 name="uboot1"         version="v1.0.0.1"       start=00000584  len=000437d0  (start=    1412 len=  276432)
-    Section  1 name=""               version=""               start=00043d54  len=00000000  (start=  277844 len=       0)
-    Section  2 name="bootargs"       version="v1.0.0.1"       start=00043d54  len=00020000  (start=  277844 len=  131072)
-    Section  3 name="kernel"         version="v1.0.0.1"       start=00063d54  len=0023fdc8  (start=  408916 len= 2358728)
-    Section  4 name="fs"             version="v1.0.0.442"     start=002a3b1c  len=00402000  (start= 2767644 len= 4202496)
-    Section  5 name="app"            version="v1.0.0.421"     start=006a5b1c  len=00947000  (start= 6970140 len= 9728000)
-    Section  6 name=""               version=""               start=00fecb1c  len=00000000  (start=16698140 len=       0)
-    Section  7 name="logo"           version="v1.0.0.1"       start=00fecb1c  len=0000f1fd  (start=16698140 len=   61949)
-    Section  8 name=""               version=""               start=00ffbd19  len=00000000  (start=16760089 len=       0)
-    Section  9 name=""               version=""               start=00ffbd19  len=00000000  (start=16760089 len=       0)
-    Mtd_part name="uboot1"         mtd="/dev/mtd9"       a=00000000  start=00000000  len=00080000
-    Mtd_part name="uboot2"         mtd="/dev/mtd9"       a=00080000  start=00080000  len=001e0000
-    Mtd_part name="bootargs"       mtd="/dev/mtd9"       a=00260000  start=00260000  len=00020000
-    Mtd_part name="kernel"         mtd="/dev/mtd9"       a=00280000  start=00280000  len=00440000
-    Mtd_part name="fs"             mtd="/dev/mtd9"       a=006c0000  start=006c0000  len=00c00000
-    Mtd_part name="app"            mtd="/dev/mtd9"       a=012c0000  start=012c0000  len=02000000
-    Mtd_part name="para"           mtd="/dev/mtd9"       a=032c0000  start=032c0000  len=00800000
-    Mtd_part name="logo"           mtd="/dev/mtd9"       a=03ac0000  start=03ac0000  len=00200000
-    Mtd_part name="ipc_img"        mtd="/dev/mtd9"       a=03cc0000  start=03cc0000  len=00b00000
-    Mtd_part name="version"        mtd="/dev/mtd9"       a=ffffffff  start=ffffffff  len=00000000
+    Section  0 name="uboot1"         version="v1.0.0.1"       start=0x00000584  len=0x000437d0  (start=    1412 len=  276432)
+    Section  1 name=""               version=""               start=0x00043d54  len=0x00000000  (start=  277844 len=       0)
+    Section  2 name="bootargs"       version="v1.0.0.1"       start=0x00043d54  len=0x00020000  (start=  277844 len=  131072)
+    Section  3 name="kernel"         version="v1.0.0.1"       start=0x00063d54  len=0x0023fdc8  (start=  408916 len= 2358728)
+    Section  4 name="fs"             version="v1.0.0.442"     start=0x002a3b1c  len=0x00402000  (start= 2767644 len= 4202496)
+    Section  5 name="app"            version="v1.0.0.421"     start=0x006a5b1c  len=0x00947000  (start= 6970140 len= 9728000)
+    Section  6 name=""               version=""               start=0x00fecb1c  len=0x00000000  (start=16698140 len=       0)
+    Section  7 name="logo"           version="v1.0.0.1"       start=0x00fecb1c  len=0x0000f1fd  (start=16698140 len=   61949)
+    Section  8 name=""               version=""               start=0x00ffbd19  len=0x00000000  (start=16760089 len=       0)
+    Section  9 name=""               version=""               start=0x00ffbd19  len=0x00000000  (start=16760089 len=       0)
+    Mtd_part name="uboot1"         mtd="/dev/mtd9"       a=0x00000000  start=0x00000000  len=0x00080000
+    Mtd_part name="uboot2"         mtd="/dev/mtd9"       a=0x00080000  start=0x00080000  len=0x001e0000
+    Mtd_part name="bootargs"       mtd="/dev/mtd9"       a=0x00260000  start=0x00260000  len=0x00020000
+    Mtd_part name="kernel"         mtd="/dev/mtd9"       a=0x00280000  start=0x00280000  len=0x00440000
+    Mtd_part name="fs"             mtd="/dev/mtd9"       a=0x006c0000  start=0x006c0000  len=0x00c00000
+    Mtd_part name="app"            mtd="/dev/mtd9"       a=0x012c0000  start=0x012c0000  len=0x02000000
+    Mtd_part name="para"           mtd="/dev/mtd9"       a=0x032c0000  start=0x032c0000  len=0x00800000
+    Mtd_part name="logo"           mtd="/dev/mtd9"       a=0x03ac0000  start=0x03ac0000  len=0x00200000
+    Mtd_part name="ipc_img"        mtd="/dev/mtd9"       a=0x03cc0000  start=0x03cc0000  len=0x00b00000
+    Mtd_part name="version"        mtd="/dev/mtd9"       a=0xffffffff  start=0xffffffff  len=0x00000000
 File passes CRC check: NVR8-7400_1705_3438_1103.pak
 ```
 
@@ -131,28 +131,28 @@ Writing header... (1552 bytes)
 Updating CRC...
 Replacement completed. New header:
 Header  magic=32725913  crc32=41ee801c  type=00006202  sections=<11>  mtd_parts=<11>
-    Section  0 name="header"         version="v1.0.0.0"       start=00000610  len=00020000  (start=    1552 len=  131072)
-    Section  1 name="loader"         version="v1.0.0.0"       start=00020610  len=000046b0  (start=  132624 len=   18096)
-    Section  2 name="fdt"            version="v1.0.0.0"       start=00024cc0  len=00006724  (start=  150720 len=   26404)
-    Section  3 name="uboot"          version="v1.0.0.0"       start=0002b3e4  len=00065358  (start=  177124 len=  414552)
-    Section  4 name="kernel"         version="v1.0.0.0"       start=0009073c  len=002e2030  (start=  591676 len= 3022896)
-    Section  5 name="fs"             version="v1.0.0.0"       start=0037276c  len=00ba557a  (start= 3614572 len=12211578)
-    Section  6 name="app"            version="v1.0.0.0"       start=00f17ce6  len=01052000  (start=15826150 len=17113088)
-    Section  7 name=""               version=""               start=01f69ce6  len=00000000  (start=32939238 len=       0)
-    Section  8 name="logo"           version="v1.0.0.0"       start=01f69ce6  len=0001dcb4  (start=32939238 len=  122036)
-    Section  9 name=""               version=""               start=01f8799a  len=00000000  (start=33061274 len=       0)
-    Section 10 name=""               version=""               start=01f8799a  len=00000000  (start=33061274 len=       0)
-    Mtd_part name="header"         mtd="/dev/mtd9"       a=00000000  start=00000000  len=00020000
-    Mtd_part name="loader"         mtd="/dev/mtd9"       a=00020000  start=00020000  len=00080000
-    Mtd_part name="fdt"            mtd="/dev/mtd9"       a=000a0000  start=000a0000  len=00080000
-    Mtd_part name="uboot"          mtd="/dev/mtd9"       a=00120000  start=00120000  len=000e0000
-    Mtd_part name="kernel"         mtd="/dev/mtd9"       a=00200000  start=00200000  len=00500000
-    Mtd_part name="fs"             mtd="/dev/mtd9"       a=00700000  start=00700000  len=00f00000
-    Mtd_part name="app"            mtd="/dev/mtd9"       a=01600000  start=01600000  len=02000000
-    Mtd_part name="para"           mtd="/dev/mtd9"       a=03600000  start=03600000  len=00800000
-    Mtd_part name="logo"           mtd="/dev/mtd9"       a=03e00000  start=03e00000  len=00100000
-    Mtd_part name="uid"            mtd="/dev/mtd9"       a=03f00000  start=03f00000  len=00100000
-    Mtd_part name="version"        mtd="/dev/mtd9"       a=ffffffff  start=ffffffff  len=00000000
+    Section  0 name="header"         version="v1.0.0.0"       start=0x00000610  len=0x00020000  (start=    1552 len=  131072)
+    Section  1 name="loader"         version="v1.0.0.0"       start=0x00020610  len=0x000046b0  (start=  132624 len=   18096)
+    Section  2 name="fdt"            version="v1.0.0.0"       start=0x00024cc0  len=0x00006724  (start=  150720 len=   26404)
+    Section  3 name="uboot"          version="v1.0.0.0"       start=0x0002b3e4  len=0x00065358  (start=  177124 len=  414552)
+    Section  4 name="kernel"         version="v1.0.0.0"       start=0x0009073c  len=0x002e2030  (start=  591676 len= 3022896)
+    Section  5 name="fs"             version="v1.0.0.0"       start=0x0037276c  len=0x00ba557a  (start= 3614572 len=12211578)
+    Section  6 name="app"            version="v1.0.0.0"       start=0x00f17ce6  len=0x01052000  (start=15826150 len=17113088)
+    Section  7 name=""               version=""               start=0x01f69ce6  len=0x00000000  (start=32939238 len=       0)
+    Section  8 name="logo"           version="v1.0.0.0"       start=0x01f69ce6  len=0x0001dcb4  (start=32939238 len=  122036)
+    Section  9 name=""               version=""               start=0x01f8799a  len=0x00000000  (start=33061274 len=       0)
+    Section 10 name=""               version=""               start=0x01f8799a  len=0x00000000  (start=33061274 len=       0)
+    Mtd_part name="header"         mtd="/dev/mtd9"       a=0x00000000  start=0x00000000  len=0x00020000
+    Mtd_part name="loader"         mtd="/dev/mtd9"       a=0x00020000  start=0x00020000  len=0x00080000
+    Mtd_part name="fdt"            mtd="/dev/mtd9"       a=0x000a0000  start=0x000a0000  len=0x00080000
+    Mtd_part name="uboot"          mtd="/dev/mtd9"       a=0x00120000  start=0x00120000  len=0x000e0000
+    Mtd_part name="kernel"         mtd="/dev/mtd9"       a=0x00200000  start=0x00200000  len=0x00500000
+    Mtd_part name="fs"             mtd="/dev/mtd9"       a=0x00700000  start=0x00700000  len=0x00f00000
+    Mtd_part name="app"            mtd="/dev/mtd9"       a=0x01600000  start=0x01600000  len=0x02000000
+    Mtd_part name="para"           mtd="/dev/mtd9"       a=0x03600000  start=0x03600000  len=0x00800000
+    Mtd_part name="logo"           mtd="/dev/mtd9"       a=0x03e00000  start=0x03e00000  len=0x00100000
+    Mtd_part name="uid"            mtd="/dev/mtd9"       a=0x03f00000  start=0x03f00000  len=0x00100000
+    Mtd_part name="version"        mtd="/dev/mtd9"       a=0xffffffff  start=0xffffffff  len=0x00000000
 ```
 
 

--- a/pakler/__init__.py
+++ b/pakler/__init__.py
@@ -1,15 +1,11 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: 2021 Vincent Mallet <vmallet@gmail.com>
 # SPDX-License-Identifier: MIT
 
 """Simple tool to manipulate PAK firmware files (list, extract, replace) for Swann and Reolink devices. See -h."""
 
-import argparse
 import io
 import os.path
 import struct
-import textwrap
 import zlib
 from typing import Optional
 
@@ -17,8 +13,6 @@ try:
     from ._version import __version__
 except ModuleNotFoundError:
     __version__ = 'dev-local'
-
-EPILOG_MARKER = "##MYEPILOG##"
 
 CHUNK_SIZE = 128 * 1024
 
@@ -420,28 +414,6 @@ def make_section_filename(section):
     return "{:02}.bin".format(section.num)
 
 
-def find_new_name(base):
-    name = base
-    suffix = 0
-    while os.path.exists(name):
-        suffix += 1
-        if suffix == 1000:
-            raise Exception("Could not find a non-existing file/directory for base: {}".format(base))
-        name = "{}.{:03}".format(base, suffix)
-
-    return name
-
-
-def make_output_file_name(filename):
-    base = filename + ".replaced"
-    return find_new_name(base)
-
-
-def make_output_dir_name(filename):
-    base = filename + ".extracted"
-    return find_new_name(base)
-
-
 def copy(fin, fout, length):
     chunk_size = CHUNK_SIZE
     while length > 0:
@@ -532,74 +504,6 @@ def replace_section(filename, section_file, section_num, output_file, section_co
         pak.header.print_debug()
 
 
-def make_epilogue_text(prog, indent, width):
-    lines = [
-        '{} ~/fw/CAM_FW.pak'.format(prog),
-        'List the content of CAM_FW.pak, auto-detecting the number of sections',
-        '',
-        '{} ~/fw/CAM_FW.pak -e -d /tmp/extracted/'.format(prog),
-        'Extract all sections of CAM_FW.pak into /tmp/extracted',
-        '',
-        '{} ~/fw/CAM_FW.pak -r -n 4 -f ~/fw/new_fs.cramfs -o ~/fw/CAM_FW_PATCHED.pak'.format(prog),
-        'From firmware file ~/fw/CAM_FW.pak, replace the 4th section with new file ~/fw/new_fs.cramfs, writing'
-        ' the output to ~/fw/CAM_FW_PATCHED.pak'
-    ]
-
-    wrapper = textwrap.TextWrapper(width, initial_indent=indent, subsequent_indent=indent)
-
-    return "\n".join(["examples:"] + [wrapper.fill(line) for line in lines])
-
-
-class EpilogizerHelpFormatter(argparse.HelpFormatter):
-    """
-    Help message formatter which injects a pre-formatted epilog text if the text to be formatted is the EPILOG_MARKER.
-    """
-
-    def __init__(self, prog, indent_increment=2, max_help_position=24, width=None) -> None:
-        super().__init__(prog, indent_increment, max_help_position, width)
-        self._my_prog = prog
-        self._my_indent = ' ' * indent_increment
-
-    def _fill_text(self, text, width, indent):
-        if text == EPILOG_MARKER:
-            return make_epilogue_text(self._my_prog, self._my_indent, width)
-        return super()._fill_text(text, width, indent)
-
-
-def parse_args():
-    parser = argparse.ArgumentParser(
-        description='%(prog)s {} (by Vincent Mallet 2021) - manipulate Swann / Reolink PAK firmware files'.format(
-            __version__),
-        formatter_class=EpilogizerHelpFormatter,
-        epilog=EPILOG_MARKER)
-
-    parser.add_argument('-v', '--version', action='version', version="%(prog)s {}".format(__version__))
-
-    pgroup = parser.add_mutually_exclusive_group()
-    pgroup.add_argument('-l', '--list', dest='list', action='store_true',
-                        help='List contents of PAK firmware file (default)')
-    pgroup.add_argument('-r', '--replace', dest='replace', action='store_true',
-                        help='Replace a section into a new PAK file')
-    pgroup.add_argument('-e', '--extract', dest='extract', action='store_true',
-                        help='Extract sections to a directory')
-    parser.add_argument('-f', '--section-file', dest='section_file', help='Input binary file for section replacement')
-    parser.add_argument('-n', '--section-num', dest='section_num', type=int, help='Section number of replaced section')
-    parser.add_argument('-o', '--output', dest='output_pak', help='Name of output PAK file when replacing a section')
-    parser.add_argument('-d', '--output-dir', dest='output_dir',
-                        help='Name of output directory when extracting sections')
-    parser.add_argument('--empty', dest='include_empty', action='store_true',
-                        help='Include empty sections when extracting')
-    parser.add_argument('filename', nargs=1, help='Name of PAK firmware file')
-
-    args = parser.parse_args()
-
-    # Set default action as "list"
-    if not (args.list or args.replace or args.extract):
-        args.list = True
-
-    return args
-
-
 def guess_section_count(filename, is64=None) -> Optional[int]:
     """
     Attempt to guess the number of sections for the given PAK firmware file.
@@ -620,30 +524,3 @@ def is_64bit(filename):
 def _print(*args, **kwargs):
     if not kwargs.pop("quiet", False):
         print(*args, **kwargs)
-
-
-def main():
-    args = parse_args()
-    filename = args.filename[0]
-
-    if args.list:
-        with PAK.from_file(filename) as pak:
-            pak.header.print_debug()
-            check_crc(filename)
-
-    elif args.extract:
-        output_dir = args.output_dir or make_output_dir_name(filename)
-        print("output: {}".format(output_dir))
-        with PAK.from_file(filename) as pak:
-            pak.extract(output_dir, args.include_empty, quiet=False)
-
-    elif args.replace:
-        if not args.section_file or not args.section_num:
-            raise Exception("replace error: need both section binary file and section number to do a replacement;"
-                            " see help")
-        output_file = args.output_pak or make_output_file_name(filename)
-        replace_section(filename, args.section_file, args.section_num, output_file)
-
-
-if __name__ == "__main__":
-    main()

--- a/pakler/__main__.py
+++ b/pakler/__main__.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 Vincent Mallet <vmallet@gmail.com>
+# SPDX-License-Identifier: MIT
+
+import argparse
+import os.path
+import textwrap
+
+from . import PAK, __version__, check_crc, replace_section
+
+EPILOG_MARKER = "##MYEPILOG##"
+
+
+class EpilogizerHelpFormatter(argparse.HelpFormatter):
+    """
+    Help message formatter which injects a pre-formatted epilog text if the text to be formatted is the EPILOG_MARKER.
+    """
+
+    def __init__(self, prog, indent_increment=2, max_help_position=24, width=None) -> None:
+        super().__init__(prog, indent_increment, max_help_position, width)
+        self._my_prog = prog
+        self._my_indent = ' ' * indent_increment
+
+    def _fill_text(self, text, width, indent):
+        if text == EPILOG_MARKER:
+            return make_epilogue_text(self._my_prog, self._my_indent, width)
+        return super()._fill_text(text, width, indent)
+
+
+def make_epilogue_text(prog, indent, width):
+    lines = [
+        '{} ~/fw/CAM_FW.pak'.format(prog),
+        'List the content of CAM_FW.pak, auto-detecting the number of sections',
+        '',
+        '{} ~/fw/CAM_FW.pak -e -d /tmp/extracted/'.format(prog),
+        'Extract all sections of CAM_FW.pak into /tmp/extracted',
+        '',
+        '{} ~/fw/CAM_FW.pak -r -n 4 -f ~/fw/new_fs.cramfs -o ~/fw/CAM_FW_PATCHED.pak'.format(prog),
+        'From firmware file ~/fw/CAM_FW.pak, replace the 4th section with new file ~/fw/new_fs.cramfs, writing'
+        ' the output to ~/fw/CAM_FW_PATCHED.pak'
+    ]
+
+    wrapper = textwrap.TextWrapper(width, initial_indent=indent, subsequent_indent=indent)
+
+    return "\n".join(["examples:"] + [wrapper.fill(line) for line in lines])
+
+
+def find_new_name(base):
+    name = base
+    suffix = 0
+    while os.path.exists(name):
+        suffix += 1
+        if suffix == 1000:
+            raise Exception("Could not find a non-existing file/directory for base: {}".format(base))
+        name = "{}.{:03}".format(base, suffix)
+
+    return name
+
+
+def make_output_file_name(filename):
+    base = filename + ".replaced"
+    return find_new_name(base)
+
+
+def make_output_dir_name(filename):
+    base = filename + ".extracted"
+    return find_new_name(base)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='%(prog)s {} (by Vincent Mallet 2021) - manipulate Swann / Reolink PAK firmware files'.format(
+            __version__),
+        formatter_class=EpilogizerHelpFormatter,
+        epilog=EPILOG_MARKER)
+
+    parser.add_argument('-v', '--version', action='version', version="%(prog)s {}".format(__version__))
+
+    pgroup = parser.add_mutually_exclusive_group()
+    pgroup.add_argument('-l', '--list', dest='list', action='store_true',
+                        help='List contents of PAK firmware file (default)')
+    pgroup.add_argument('-r', '--replace', dest='replace', action='store_true',
+                        help='Replace a section into a new PAK file')
+    pgroup.add_argument('-e', '--extract', dest='extract', action='store_true',
+                        help='Extract sections to a directory')
+    parser.add_argument('-f', '--section-file', dest='section_file', help='Input binary file for section replacement')
+    parser.add_argument('-n', '--section-num', dest='section_num', type=int, help='Section number of replaced section')
+    parser.add_argument('-o', '--output', dest='output_pak', help='Name of output PAK file when replacing a section')
+    parser.add_argument('-d', '--output-dir', dest='output_dir',
+                        help='Name of output directory when extracting sections')
+    parser.add_argument('--empty', dest='include_empty', action='store_true',
+                        help='Include empty sections when extracting')
+    parser.add_argument('filename', help='Name of PAK firmware file')
+
+    args = parser.parse_args()
+
+    # Set default action as "list"
+    if not (args.list or args.replace or args.extract):
+        args.list = True
+
+    return args
+
+
+def main():
+    args = parse_args()
+    filename = args.filename
+
+    if args.list:
+        with PAK.from_file(filename) as pak:
+            pak.header.print_debug()
+            check_crc(filename)
+
+    elif args.extract:
+        output_dir = args.output_dir or make_output_dir_name(filename)
+        print("output: {}".format(output_dir))
+        with PAK.from_file(filename) as pak:
+            pak.extract(output_dir, args.include_empty, quiet=False)
+
+    elif args.replace:
+        if not args.section_file or not args.section_num:
+            raise Exception("replace error: need both section binary file and section number to do a replacement;"
+                            " see help")
+        output_file = args.output_pak or make_output_file_name(filename)
+        replace_section(filename, args.section_file, args.section_num, output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,14 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",
 ]
 dynamic = ["version"]
 
 [project.scripts]
-pakler = "pakler.__init__:main"
+pakler = "pakler.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/vmallet/pakler"


### PR DESCRIPTION
You might want to use pakler as a library on top/instead of using it as a command-line tool. But right now there's no "consolidated" way of manipulating a pak file, and you have to call at least 3 functions before you can start: `is_64bit`, then `guess_section_count` and `read_header`. It's also not easy to manipulate pak files that are not an actual on-disk file, and as you can see [here](https://github.com/AT0myks/reolink-fw/blob/1bcf628db52867b112690cc9e7eb9efe59ed0f26/reolinkfw/mypakler.py) I had to copy and adapt some code to make it work.

This PR adds a `PAK` class that aims to solve these problems by wrapping all these functions into it. Now you can simply do
```py
with PAK.from_file("firmware.pak") as pak:
    print(pak.header)
    print(pak.partitions)
    pak.extract("destdir")
    pak.save_section(pak.sections[0], "sec0.bin")
    section_bytes = pak.extract_section(pak.sections[0])
```

This has made `is_64bit`, `guess_section_count`, `extract`, `extract_section`, `calc_crc` and `read_header` a bit redundant but I left them in for compatibility reasons. If you're okay with removing them I can do that in an other commit. In the new code `section_count == mtd_part_count` is assumed. I don't know about Swann firmwares but for Reolink ones this seems to always be true.

The `__repr__` functionality has been moved to `debug_str()` and `__repr__` now returns a more appropriate string representation. Previously if you did for example `print(header.mtd_parts)` you would get something like
```
[Mtd_part name="loader"         mtd="/dev/mtd10"      a=00000000  start=00000000  len=00010000, Mtd_part name="ext"            mtd="/dev/mtd10"      a=00010000  start=00010000  len=00010000, Mtd_part name="uitron"         mtd="/dev/mtd10"      a=00020000  start=00020000  len=003a0000, Mtd_part name="uboot"          mtd="/dev/mtd10"      a=003c0000  start=003c0000  len=00050000, Mtd_part name="bootargs"       mtd="/dev/mtd10"      a=00410000  start=00410000  len=00010000, Mtd_part name="kernel"         mtd="/dev/mtd10"      a=00420000  start=00420000  len=00200000, Mtd_part name="fs"             mtd="/dev/mtd10"      a=00620000  start=00620000  len=00900000, Mtd_part 
name="app"            mtd="/dev/mtd10"      a=ffffffff  start=ffffffff  len=00000000, Mtd_part name="para"           mtd="/dev/mtd10"      a=00f20000  start=00f20000  len=000c0000, Mtd_part name="NOUSE"          mtd="/dev/mtd10"      a=ffffffff  start=ffffffff  len=00000000, Mtd_part name="ptzmcu"         mtd="/dev/mtd10"      a=ffffffff  start=ffffffff  len=00000000]
```
but now this
```
[MtdPart('loader'), MtdPart('ext'), MtdPart('uitron'), MtdPart('uboot'), MtdPart('bootargs'), MtdPart('kernel'), MtdPart('fs'), MtdPart('app'), MtdPart('para'), MtdPart('NOUSE'), MtdPart('ptzmcu')]
```
is obviously easier to read.

Other changes include
- Renaming `serialize` to `__bytes__` to allow calling `bytes()` on instances of `Section`, `MtdPart` and `Header`
- Adding `0x` prefix to numbers displayed in hexadecimal to make the base explicit
- Use f-strings instead of `.format()` where it makes code more readable
- Use higher level `pathlib.Path` instead of `os.path`
- Move the command-line code to `__main__.py`

If you merge this, could you please make a new release? I didn't want to ask in each PR but after this one that will be basically all the changes I needed to finally update pakler in my project.