### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release on PyPI
+
+on:
+    push:
+        tags:
+            - v*
+
+jobs:
+    pypi-publish:
+        name: Upload release to PyPI
+        runs-on: ubuntu-latest
+        environment:
+            name: release
+            url: https://pypi.org/p/pakler
+        permissions:
+            id-token: write
+        steps:
+          - name: Checkout repo
+            uses: actions/checkout@v3
+          - name: Set up Python
+            uses: actions/setup-python@v4
+            with:
+                python-version: "3.8"
+          - name: Install dependencies
+            run: |
+                python -m pip install --upgrade pip
+                python -m pip install build
+          - name: Build package
+            run: python -m build
+          - name: Upload distributions
+            uses: actions/upload-artifact@v3
+            with:
+                name: dist
+                path: dist/*
+                if-no-files-found: error
+          - name: Publish package distributions to PyPI
+            uses: pypa/gh-action-pypi-publish@release/v1
+            with:
+                print-hash: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 prune .idea
+prune .github
 exclude *.iml
 exclude .gitignore


### PR DESCRIPTION
Setup documentation is [here](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) if needed. Here are the steps:

Go [here](https://pypi.org/manage/project/pakler/settings/publishing/) and add a new publisher with these settings:
- Owner: `vmallet`
- Repository name: `pakler`
- Workflow name: `release.yml`
- Environment name: `release`

Then go [here](https://github.com/vmallet/pakler/settings/environments/new) and add a new environment called `Release`. You just have to create it, nothing more.

Once that's done and the PR is merged, you might want to delete the current v0.2.0 tag and create it again so that it points to the latest commit. Then, push the new tag and the workflow should run and upload the release on PyPI.