### PR TITLE
Move to ctypes and add support for `.paks` files

### DIFF
--- a/pakler/__init__.py
+++ b/pakler/__init__.py
@@ -222,7 +222,7 @@ class PAK:
         return cls.from_fd(open(path, "rb"), offset)
 
 
-def check_crc(filename, section_count=None, mtd_part_count=None, is64=None):
+def check_crc(filename):
     """Check the PAK file's crc matches the crc in its header."""
     if isinstance(filename, ZipExtFile):
         with PAK.from_fd(filename) as pak:
@@ -242,7 +242,7 @@ def check_crc(filename, section_count=None, mtd_part_count=None, is64=None):
     return True
 
 
-def update_crc(filename, section_count=None, is64=None):
+def update_crc(filename):
     """Recompute the PAK file's crc and store it in its header.
 
     Note: the PAK file is modified by this operation.
@@ -276,15 +276,13 @@ def copy(fin, fout, length):
         length -= chunk_size
 
 
-def replace_section(filename, section_file: Path, section_num, output_file: Path, section_count=None, mtd_part_count=None):
+def replace_section(filename, section_file: Path, section_num, output_file: Path):
     """Copy the given PAK file into new output_file, replacing the specified section.
 
     :param filename: name of the input PAK firmware file
     :param section_file: name of the file containing the section to be swapped-in
     :param section_num: number of the section to be replaced
     :param output_file: name of the output file which will contained the modified PAK file
-    :param section_count: number of sections in the input PAK file
-    :param mtd_part_count:  optional number of mtd_parts in the input PAK file
     """
     with PAK.from_file(filename) as pak:
         if pak.pak_type == PAKType.PAKS:

--- a/pakler/__init__.py
+++ b/pakler/__init__.py
@@ -6,9 +6,17 @@
 import io
 import struct
 import zlib
+from ctypes import sizeof
 from pathlib import Path
-from typing import Optional
 from zipfile import ZipExtFile
+
+from pakler.structure import (
+    PAK32Header,
+    PAK32Section,
+    PAK64Header,
+    PAK64Section,
+    PAKPartition,
+)
 
 try:
     from ._version import __version__
@@ -20,206 +28,20 @@ CHUNK_SIZE = 128 * 1024
 PAK_MAGIC = 0x32725913
 PAK_MAGIC_BYTES = PAK_MAGIC.to_bytes(4, "little")
 
-SECTION_FORMAT = "<32s24sII"
-SECTION_FORMAT_64 = "<32s24sQQ"
-SECTION_FIELDS = ['name',  # TODO: Docs
-                  'version',
-                  'start',
-                  'len']
-SECTION_STRINGS = ['name', 'version']
-SECTION_SIZE = struct.calcsize(SECTION_FORMAT)  # 64
-SECTION_SIZE_64 = struct.calcsize(SECTION_FORMAT_64)  # 72
-
-MTD_PART_FORMAT = "<32sI32sII"
-MTD_PART_FIELDS = ['name',
-                   'a',
-                   'mtd',
-                   'start',
-                   'len']
-MTD_PART_STRINGS = ['name',
-                    'mtd']
-MTD_PART_SIZE = struct.calcsize(MTD_PART_FORMAT)  # 76
-
-HEADER_FORMAT = "<III"
-HEADER_FORMAT_64 = "<QQQ"
-HEADER_FIELDS = ['magic',
-                 'crc32',
-                 'type']
 HEADER_CRC_OFFSET = 4  # Offset of the CRC in the file
 HEADER_CRC_OFFSET_64 = 8
-HEADER_HEADER_SIZE = struct.calcsize(HEADER_FORMAT)  # Size of the header's header (first 12 bytes)
-HEADER_HEADER_SIZE_64 = struct.calcsize(HEADER_FORMAT_64)  # First 24 bytes
-
-
-def calc_header_size(section_count, mtd_part_count=None, is64=False):
-    """Return the calculated size of the header given a number of sections (and optionally of mtd_parts)."""
-    if not mtd_part_count:
-        mtd_part_count = section_count
-
-    if is64:
-        return HEADER_HEADER_SIZE_64 + (section_count * SECTION_SIZE_64) + (mtd_part_count * MTD_PART_SIZE)
-    return HEADER_HEADER_SIZE + (section_count * SECTION_SIZE) + (mtd_part_count * MTD_PART_SIZE)
-
-
-def decode_strings(obj, fields):
-    """Decode (utf-8) 0-padded binary strings in the obj's fields to normal strings."""
-    for field in fields:
-        cstr = getattr(obj, field)
-        fixed = cstr.rstrip(b'\0').decode('utf-8')
-        setattr(obj, field, fixed)
-
-
-def quote_string(string):
-    """Return the string surrounded with double-quotes."""
-    return f'"{string}"'
-
-
-class Section:
-    """A header's 'section'."""
-
-    def __init__(self, buf, num, is64=False):
-        self.num = num
-        self.name = None
-        self.version = None
-        self.start = 0
-        self.len = 0
-        self.section_format = SECTION_FORMAT_64 if is64 else SECTION_FORMAT
-
-        fields = zip(SECTION_FIELDS, struct.unpack(self.section_format, buf))
-        for key, val in fields:
-            setattr(self, key, val)
-
-        decode_strings(self, SECTION_STRINGS)
-
-    def __repr__(self):
-        return f"{self.__class__.__qualname__}({self.name!r})"
-
-    def __iter__(self):
-        for key in dir(self):
-            if not key.startswith('_'):
-                yield key, getattr(self, key)
-
-    def __bytes__(self):
-        return struct.pack(self.section_format, self.name.encode(), self.version.encode(), self.start, self.len)
-
-    def debug_str(self):
-        return 'Section {:2} name={:16} version={:16} start=0x{:08x}  len=0x{:08x}  (start={:8} len={:8})'.format(
-            self.num, quote_string(self.name), quote_string(self.version), self.start, self.len, self.start, self.len)
-
-
-class MtdPart:
-    """A header's 'Mtd_Part'."""
-
-    def __init__(self, buf):
-        self.name = None
-        self.a = 0
-        self.mtd = None
-        self.start = 0
-        self.len = 0
-
-        fields = zip(MTD_PART_FIELDS, struct.unpack(MTD_PART_FORMAT, buf))
-        for key, val in fields:
-            setattr(self, key, val)
-
-        decode_strings(self, MTD_PART_STRINGS)
-
-    def __repr__(self):
-        return f"{self.__class__.__qualname__}({self.name!r})"
-
-    def __iter__(self):
-        for key in dir(self):
-            if not key.startswith('_'):
-                yield key, getattr(self, key)
-
-    def __bytes__(self):
-        return struct.pack(MTD_PART_FORMAT, self.name.encode(), self.a, self.mtd.encode(), self.start, self.len)
-
-    def debug_str(self):
-        return 'Mtd_part name={:16} mtd={:16}  a=0x{:08x}  start=0x{:08x}  len=0x{:08x}'.format(
-            quote_string(self.name), quote_string(self.mtd), self.a, self.start, self.len)
-
-
-class Header:
-    """PAK file header."""
-
-    def __init__(self, buf, section_count, mtd_part_count, is64=False):
-        self.magic = 0
-        self.crc32 = 0
-        self.type = 0
-        self.sections = []
-        self.mtd_parts = []
-        self.is64 = is64
-        if is64:
-            self.header_format = HEADER_FORMAT_64
-            self.header_header_size = HEADER_HEADER_SIZE_64
-            self.section_size = SECTION_SIZE_64
-        else:
-            self.header_format = HEADER_FORMAT
-            self.header_header_size = HEADER_HEADER_SIZE
-            self.section_size = SECTION_SIZE
-
-        self.size = calc_header_size(section_count, mtd_part_count, is64)
-        if len(buf) != self.size:
-            raise Exception(f"Invalid header buffer size, expected: {self.size}, got: {len(buf)}")
-
-        fields = zip(HEADER_FIELDS, struct.unpack(self.header_format, buf[:self.header_header_size]))
-        for key, val in fields:
-            setattr(self, key, val)
-
-        buf = buf[self.header_header_size:]
-        for num in range(section_count):
-            self.sections.append(Section(buf[:self.section_size], num, is64))
-            buf = buf[self.section_size:]
-
-        for _ in range(mtd_part_count):
-            self.mtd_parts.append(MtdPart(buf[:MTD_PART_SIZE]))
-            buf = buf[MTD_PART_SIZE:]
-
-        self._check_errors(buf[:-4])
-
-    def __repr__(self):
-        return '{}(magic=0x{:08x}, crc32=0x{:08x}, type=0x{:08x})'.format(
-            self.__class__.__qualname__, self.magic, self.crc32, self.type, len(self.sections), len(self.mtd_parts))
-
-    def __iter__(self):
-        for key in dir(self):
-            if not key.startswith('_'):
-                yield key, getattr(self, key)
-
-    def __bytes__(self):
-        buf = struct.pack(self.header_format, self.magic, self.crc32, self.type)
-        for section in self.sections:
-            buf += bytes(section)
-        for mtd_part in self.mtd_parts:
-            buf += bytes(mtd_part)
-
-        if len(buf) != self.size:
-            raise Exception(f"Serialization error: should have been {self.size} bytes, but produced: {len(buf)} bytes")
-
-        return buf
-
-    def _check_errors(self, buf_crc):
-        if self.magic != PAK_MAGIC:
-            raise Exception(f"Wrong header magic: expected 0x{PAK_MAGIC:08x}, got 0x{self.magic:08x}")
-
-    def debug_str(self):
-        return 'Header  magic=0x{:08x}  crc32=0x{:08x}  type=0x{:08x}  sections=<{}>  mtd_parts=<{}>'.format(
-            self.magic, self.crc32, self.type, len(self.sections), len(self.mtd_parts))
-
-    def print_debug(self):
-        print(self.debug_str())
-        for section in self.sections:
-            print(f"    {section.debug_str()}")
-        for part in self.mtd_parts:
-            print(f"    {part.debug_str()}")
 
 
 class PAK:
 
-    def __init__(self, fd, header: Header, closefd=True) -> None:
+    def __init__(self, fd, header, is64, closefd=True) -> None:
         self._fd = fd
         self._header = header
+        self._is64 = is64
         self._closefd = closefd
+        self._sections = []
+        self._partitions = []
+        self._read_file()
 
     def __enter__(self):
         return self
@@ -246,23 +68,24 @@ class PAK:
 
     @property
     def sections(self):
-        return self._header.sections
+        return self._sections
 
     @property
     def partitions(self):
-        return self._header.mtd_parts
+        return self._partitions
 
     @property
     def is64(self):
-        return self._header.is64
+        return self._is64
 
     def close(self):
         self._fd.close()
+        self._fd = None
 
     def calc_crc(self):
         """Calculate the PAK file's CRC (which should match the header's CRC)."""
         crc = 0xffffffff
-        self._fd.seek(self.header.size)
+        self._fd.seek(self._sections[0].start)
 
         for chunk in iter(lambda: self._fd.read(CHUNK_SIZE), b''):
             crc = zlib.crc32(chunk, crc)
@@ -270,18 +93,18 @@ class PAK:
         buf = b'\2\0\0\0'  # TODO explain...
         crc = zlib.crc32(buf, crc)
 
-        self._fd.seek(self.header.header_header_size)
-        buf = self._fd.read(len(self.sections) * self.header.section_size)
+        self._fd.seek(sizeof(self._header))
+        buf = self._fd.read(len(self.sections) * sizeof(self._sections[0]))
         crc = zlib.crc32(buf, crc)
 
         crc = crc ^ 0xffffffff
         return crc
 
-    def extract_section(self, section: Section):
+    def extract_section(self, section):
         self._fd.seek(section.start)
         return self._fd.read(section.len)
 
-    def save_section(self, section: Section, out_filename):
+    def save_section(self, section, out_filename):
         self._fd.seek(section.start)
         with open(out_filename, "wb") as fout:
             copy(self._fd, fout, section.len)
@@ -294,13 +117,36 @@ class PAK:
         if not output_dir.exists() or not output_dir.is_dir():
             raise Exception(f"Invalid output directory: {output_dir}")
 
-        for section in self.sections:
-            out_filename = output_dir / make_section_filename(section)
+        for num, section in enumerate(self.sections):
+            out_filename = output_dir / make_section_filename(section, num)
             if section.len or include_empty:
-                _print(f"Extracting section {section.num} ({section.len} bytes) into {out_filename}", quiet=quiet)
+                _print(f"Extracting section {num} ({section.len} bytes) into {out_filename}", quiet=quiet)
                 self.save_section(section, out_filename)
             else:
-                _print(f"Skipping empty section {section.num}", quiet=quiet)
+                _print(f"Skipping empty section {num}", quiet=quiet)
+
+    def debug_str(self):
+        return 'Header  magic=0x{:08x}  crc32=0x{:08x}  type=0x{:08x}  sections=<{}>  mtd_parts=<{}>'.format(
+            self.magic, self.crc, self.type, len(self.sections), len(self.partitions))
+
+    def print_debug(self):
+        print(self.debug_str())
+        for num, section in enumerate(self.sections):
+            print(f"    {section.debug_str(num)}")
+        for part in self.partitions:
+            print(f"    {part.debug_str()}")
+
+    def _read_file(self):
+        sec_cls = PAK64Section if self.is64 else PAK32Section
+        while True:
+            section = sec_cls.from_fd(self._fd)
+            if self._sections and section.name == self._sections[0].name:
+                # We have reached (and read a part of) the first partition.
+                self._fd.seek(-sizeof(sec_cls), 1)
+                break
+            self._sections.append(section)
+        for _ in range(len(self._sections)):
+            self._partitions.append(PAKPartition.from_fd(self._fd))
 
     @staticmethod
     def is_64bit(fd):
@@ -318,47 +164,23 @@ class PAK:
         return sum((group1, group2, group3)) == 0
 
     @staticmethod
-    def get_section_count(fd, is64) -> Optional[int]:
-        """
-        Attempt to guess the number of sections for the given PAK firmware file.
-
-        :return: Guessed number of sections, or None if it couldn't be guessed
-        """
-        offset = HEADER_HEADER_SIZE_64 if is64 else HEADER_HEADER_SIZE
-        section_size = SECTION_SIZE_64 if is64 else SECTION_SIZE
-        fd.seek(offset, 1)
-        first_section = Section(fd.read(section_size), 0, is64)
-        first_section_name = first_section.name.encode("utf-8")
-        for count in range(30):
-            data = fd.read(section_size)
-            if data.startswith(first_section_name):
-                return count + 1
-        return None
-
-    @staticmethod
-    def read_header(fd, section_count, is64):
+    def read_header(fd, is64):
         """Read and parse the header of a PAK firmware file.
 
         :param fd: file object representing the PAK firmware file
-        :param section_count: number of sections present in the header
         :param is64: bitness of the PAK firmware
         :return: the parsed Header object
         """
-        header_size = calc_header_size(section_count, section_count, is64)
-        buf = fd.read(header_size)
-        if len(buf) != header_size:
-            raise Exception(f"Header size error, expected: {header_size}, got: {len(buf)}")
-        return Header(buf, section_count, section_count, is64)
+        cls = PAK64Header if is64 else PAK32Header
+        return cls.from_fd(fd)
 
     @classmethod
     def from_fd(cls, fd, offset=0, closefd=True):
         fd.seek(offset)
         is64 = cls.is_64bit(fd)
         fd.seek(offset)
-        section_count = cls.get_section_count(fd, is64)
-        fd.seek(offset)
-        header = cls.read_header(fd, section_count, is64)
-        return cls(fd, header, closefd)
+        header = cls.read_header(fd, is64)
+        return cls(fd, header, is64, closefd)
 
     @classmethod
     def from_bytes(cls, bytes_, offset=0):
@@ -404,11 +226,11 @@ def update_crc(filename, section_count=None, is64=None):
         f.write(struct.pack(fmt, crc))
 
 
-def make_section_filename(section):
+def make_section_filename(section, num):
     # TODO: should sanitize section name before turning it into a filename
     if section.name:
-        return f"{section.num:02}_{section.name}.bin"
-    return f"{section.num:02}.bin"
+        return f"{num:02}_{section.name}.bin"
+    return f"{num:02}.bin"
 
 
 def copy(fin, fout, length):
@@ -434,7 +256,6 @@ def replace_section(filename, section_file: Path, section_num, output_file: Path
     :param mtd_part_count:  optional number of mtd_parts in the input PAK file
     """
     with PAK.from_file(filename) as pak:
-        new_header = pak.header
         section_count = len(pak.sections)
 
     if not section_file.is_file():
@@ -451,30 +272,35 @@ def replace_section(filename, section_file: Path, section_num, output_file: Path
     print(f"Replacement file : {section_file}")
 
     with PAK.from_file(filename) as pak, open(section_file, "rb") as fsection, open(output_file, "wb") as fout:
+        metadata_size = sizeof(pak.header) + section_count * (sizeof(pak.sections[0]) + sizeof(pak.partitions[0]))
         # Write placeholder header
-        fout.write(bytearray(new_header.size))
+        fout.write(bytearray(metadata_size))
 
-        for section in pak.sections:
+        for num, section in enumerate(pak.sections):
             pak._fd.seek(section.start)
-            new_header.sections[section.num].start = fout.tell()  # TODO: set up a check in Header.init() to validate sections[num].num==num
-            if section.num == section_num:
-                new_header.sections[section.num].len = section_len
-                print(f"Replacing section {section.num} ({section.len} bytes) with {section_len} bytes")
+            section._start = fout.tell()
+            if num == section_num:
+                print(f"Replacing section {num} ({section.len} bytes) with {section_len} bytes")
                 copy(fsection, fout, section_len)
+                section._len = section_len
             else:
-                print(f"Copying section {section.num} ({section.len} bytes)")
+                print(f"Copying section {num} ({section.len} bytes)")
                 copy(pak._fd, fout, section.len)
 
-        print(f"Writing header... ({new_header.size} bytes)")
+        print(f"Writing header... ({metadata_size} bytes)")
         fout.seek(0)
-        fout.write(bytes(new_header))
+        fout.write(bytes(pak.header))
+        for section in pak.sections:
+            fout.write(bytes(section))
+        for partition in pak.partitions:
+            fout.write(bytes(partition))
 
     print("Updating CRC...")
     update_crc(output_file)
 
     print("Replacement completed. New header: ")
     with PAK.from_file(output_file) as pak:
-        pak.header.print_debug()
+        pak.print_debug()
 
 
 def _print(*args, **kwargs):

--- a/pakler/__main__.py
+++ b/pakler/__main__.py
@@ -113,7 +113,7 @@ def main():
     if args.list:
         if is_pak_file(filename):
             with PAK.from_file(filename) as pak:
-                pak.header.print_debug()
+                pak.print_debug()
                 check_crc(filename)
         else:
             with ZipFile(filename) as myzip:
@@ -121,7 +121,7 @@ def main():
                     with myzip.open(name) as file:
                         if is_pak_file(file):
                             with PAK.from_fd(file, closefd=False) as pak:
-                                pak.header.print_debug()
+                                pak.print_debug()
                             check_crc(file)
 
     elif args.extract:

--- a/pakler/__main__.py
+++ b/pakler/__main__.py
@@ -103,6 +103,13 @@ def parse_args():
     return args
 
 
+def _check_crc(filename):
+    try:
+        check_crc(filename)
+    except Exception as e:
+        print(e)
+
+
 def main():
     args = parse_args()
     filename = args.filename
@@ -114,7 +121,7 @@ def main():
         if is_pak_file(filename):
             with PAK.from_file(filename) as pak:
                 pak.print_debug()
-                check_crc(filename)
+                _check_crc(filename)
         else:
             with ZipFile(filename) as myzip:
                 for name in myzip.namelist():
@@ -122,7 +129,7 @@ def main():
                         if is_pak_file(file):
                             with PAK.from_fd(file, closefd=False) as pak:
                                 pak.print_debug()
-                            check_crc(file)
+                            _check_crc(file)
 
     elif args.extract:
         output_dir = args.output_dir or make_output_dir_name(filename)

--- a/pakler/structure.py
+++ b/pakler/structure.py
@@ -1,0 +1,151 @@
+from ctypes import LittleEndianStructure, c_char, c_uint32, c_uint64, sizeof
+
+
+class _Base(LittleEndianStructure):
+
+    def __iter__(self):
+        # This allows calling dict() on instances of this class.
+        classes = []
+        for cls in self.__class__.__mro__:
+            classes.append(cls)
+            if cls == _Base:
+                break
+        seen = set()
+        for cls in reversed(classes):
+            try:
+                cls_fields = cls._fields_
+            except AttributeError:
+                continue
+            for field in cls_fields:
+                if field not in seen:
+                    seen.add(field)
+                    name = field[0]
+                    prop = name.lstrip('_')
+                    try:
+                        attr = getattr(self, prop)
+                    except AttributeError:
+                        attr = getattr(self, name)
+                    else:
+                        name = prop
+                    yield name, dict(attr) if isinstance(attr, _Base) else attr
+
+    @classmethod
+    def from_fd(cls, fd):
+        return cls.from_buffer_copy(fd.read(sizeof(cls)))
+
+
+class _PAKHeader(_Base):
+
+    @property
+    def magic(self):
+        return self._magic
+
+    @property
+    def crc32(self):
+        return self._crc32
+
+    @property
+    def type(self):
+        return self._type
+
+
+class PAK32Header(_PAKHeader):
+    _fields_ = [
+        ("_magic", c_uint32),
+        ("_crc32", c_uint32),
+        ("_type", c_uint32),
+    ]
+
+
+class PAK64Header(_PAKHeader):
+    _fields_ = [
+        ("_magic", c_uint64),
+        ("_crc32", c_uint64),
+        ("_type", c_uint64),
+    ]
+
+
+class _PAKSection(_Base):
+    _fields_ = [
+        ("_name", c_char * 32),
+        ("_version", c_char * 24),
+    ]
+
+    @property
+    def name(self):
+        return self._name.decode()
+
+    @property
+    def version(self):
+        return self._version.decode()
+
+    @property
+    def start(self):
+        return self._start
+
+    @property
+    def len(self):
+        return self._len
+
+    def __repr__(self):
+        return f"{self.__class__.__qualname__}({self.name!r})"
+
+    def debug_str(self, num):
+        return 'Section {:2} name={:16} version={:16} start=0x{:08x}  len=0x{:08x}  (start={:8} len={:8})'.format(
+            num, quote_string(self.name), quote_string(self.version), self.start, self.len, self.start, self.len)
+
+
+class PAK32Section(_PAKSection):
+    _fields_ = [
+        ("_start", c_uint32),
+        ("_len", c_uint32),
+    ]
+
+
+class PAK64Section(_PAKSection):
+    _fields_ = [
+        ("_start", c_uint64),
+        ("_len", c_uint64),
+    ]
+
+
+class PAKPartition(_Base):
+    _fields_ = [
+        ("_name", c_char * 32),
+        ("_a", c_uint32),
+        ("_mtd", c_char * 32),
+        ("_start", c_uint32),
+        ("_len", c_uint32),
+    ]
+
+    @property
+    def name(self):
+        return self._name.decode()
+
+    @property
+    def a(self):
+        return self._a
+
+    @property
+    def mtd(self):
+        return self._mtd.decode()
+
+    @property
+    def start(self):
+        return self._start
+
+    @property
+    def len(self):
+        return self._len
+
+    def __repr__(self):
+        return f"{self.__class__.__qualname__}({self.name!r})"
+
+    def debug_str(self):
+        return 'Mtd_part name={:16} mtd={:16}  a=0x{:08x}  start=0x{:08x}  len=0x{:08x}'.format(
+            quote_string(self.name), quote_string(self.mtd), self.a, self.start, self.len)
+
+
+def quote_string(string):
+    """Return the string surrounded with double-quotes."""
+    return f'"{string}"'

--- a/pakler/structure.py
+++ b/pakler/structure.py
@@ -146,6 +146,87 @@ class PAKPartition(_Base):
             quote_string(self.name), quote_string(self.mtd), self.a, self.start, self.len)
 
 
+class PAKSHeader(_Base):
+    _fields_ = [
+        ("_magic", c_uint32),
+        ("_unknown0", c_uint32),  # one of these is probably a checksum (maybe both)
+        ("_file_size", c_uint32),
+        ("_unknown1", c_uint32),  # always 1?
+        ("_unknown2", c_uint32),  # always 0?
+        ("_bdid", c_uint32),
+        ("_unknown3", c_uint32),  # one of these is probably a checksum (maybe both)
+        ("_hwver", c_char * 32),
+        ("_fwver", c_char * 32),
+        ("_data_size", c_uint32),  # _file_size - 104 (header size)
+        ("_nb_sections", c_uint32),
+        ("_unknown4", c_uint32),  # always 0?
+    ]
+
+    @property
+    def magic(self):
+        return self._magic
+
+    @property
+    def file_size(self):
+        return self._file_size
+
+    @property
+    def hwver(self):
+        return self._hwver.decode()
+
+    @property
+    def fwver(self):
+        return self._fwver.decode()
+
+    @property
+    def data_size(self):
+        return self._data_size
+
+    @property
+    def nb_sections(self):
+        return self._nb_sections
+
+
+class PAKSSection(_Base):
+    _fields_ = [
+        ("_imgs", c_uint32),
+        ("_checksum", c_uint32),
+        ("_name", c_char * 32),
+        ("_version", c_char * 32),
+        ("_len", c_uint32),
+        ("_unknown0", c_uint32),  # may be equal for different firmwares of the same device. might be needed during upgrade process?. always higher than previous section's?
+        ("_unknown1", c_uint32),  # may be equal for different firmwares of the same device. might be needed during upgrade process?
+        ("_unknown2", c_uint32),  # always 0?
+    ]
+
+    @property
+    def checksum(self):
+        return self._checksum
+
+    @property
+    def name(self):
+        return self._name.decode()
+
+    @property
+    def version(self):
+        return self._version.decode()
+
+    @property
+    def len(self):
+        return self._len
+
+    @property
+    def start(self):
+        return self._start
+
+    def __repr__(self):
+        return f"{self.__class__.__qualname__}({self.name!r})"
+
+    def debug_str(self, num):
+        return 'Section {:2} name={:16} version={:16} start=0x{:08x}  len=0x{:08x}  (start={:8} len={:8})'.format(
+            num, quote_string(self.name), quote_string(self.version), self.start, self.len, self.start, self.len)
+
+
 def quote_string(string):
     """Return the string surrounded with double-quotes."""
     return f'"{string}"'


### PR DESCRIPTION
@pixeldoc2000 recently shared [links](https://github.com/AT0myks/reolink-fw-archive/discussions/40#discussion-5865573) of firmwares returned by an endpoint called by the Reolink desktop app. Theses files have a different format from the ones that you can get on their download center (and basically anywhere else). It's not too complicated and it seems to carry a bit more information about the sections. Instead of having all the metadata at the beginning, each section is preceded by its description. It doesn't have any partition. I wonder if the hardware version in the header is here to prevent installation on the wrong device. I'm not sure what all the fields mean but for now this is enough to seamlessly add basic support of their structure.

Merging `Header` into `PAK` and going from struct to ctypes was on my list but with this new file format it made sense to do it now. If there's more formats in the future it'll be easier to add them. And I think it's more natural to have the sections and partitions be directly attached to the file rather than the header, especially with the way sections are laid out in these `.paks`.