### PR TITLE
Type hints, 3.6 ZIP error and better file handling

### DIFF
--- a/pakler/__main__.py
+++ b/pakler/__main__.py
@@ -130,6 +130,8 @@ def main() -> None:
             with PAK.from_file(filename) as pak:
                 pak.print_debug()
                 _check_crc(filename)
+        elif sys.version_info < (3, 7):
+            sys.exit("error: pakler does not support ZIP files on Python 3.6 (can't seek)")
         else:
             with ZipFile(filename) as myzip:
                 for name in myzip.namelist():
@@ -145,6 +147,8 @@ def main() -> None:
         if is_pak_file(filename):
             with PAK.from_file(filename) as pak:
                 pak.extract(output_dir, args.include_empty, quiet=False)
+        elif sys.version_info < (3, 7):
+            sys.exit("error: pakler does not support ZIP files on Python 3.6 (can't seek)")
         else:
             with ZipFile(filename) as myzip:
                 for name in myzip.namelist():

--- a/pakler/types.py
+++ b/pakler/types.py
@@ -1,0 +1,31 @@
+import argparse
+import array
+import io
+import mmap
+from os import PathLike
+from pathlib import Path
+from typing import BinaryIO, Union
+
+# io.BufferedIOBase is for ZipExtFile
+IOBytes = Union[BinaryIO, io.BufferedIOBase]
+
+StrOrBytesPath = Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
+FileDescriptorOrPath = Union[int, StrOrBytesPath]
+
+ReadOnlyBuffer = bytes
+WriteableBuffer = Union[bytearray, memoryview, array.array, mmap.mmap]
+ReadableBuffer = Union[ReadOnlyBuffer, WriteableBuffer]
+
+Unused = object
+
+
+class MainArgs(argparse.Namespace):
+    list: bool
+    replace: bool
+    extract: bool
+    section_file: Path
+    section_num: int
+    output_pak: Path
+    output_dir: Path
+    include_empty: bool
+    filename: Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",
+    "Typing :: Typed",
 ]
 dynamic = ["version"]
 
@@ -40,6 +41,7 @@ Issues = "https://github.com/vmallet/pakler/issues"
 
 [tool.setuptools]
 packages = ["pakler"]
+package-data = {pakler = ["py.typed"]}
 
 [tool.setuptools_scm]
 write_to = "pakler/_version.py"


### PR DESCRIPTION
There were already a few type hints in the code so here's the rest. While testing that on 3.6 I found that in this version `seek()` was not added yet to `ZipExtFile` so you'd get an `io.UnsupportedOperation: seek` error when using pakler with a ZIP file which isn't very helpful. Exiting with a nicer error message is more meaningful to the user. Last change was mostly to get rid of the type checker errors after adding the type hints, but it will also show a nicer error message if there is an attempt to use the file after it's been closed. Allowing `close()` to be called more than once and the `closed` property bring the functionality closer to file-related objects of the standard library like `io.IOBase`.